### PR TITLE
ci: remove lint check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,3 @@ jobs:
       - run: npm ci
       - run: npm run test:tsc
       - run: npm run test:tsd
-      - run: npm run lint


### PR DESCRIPTION
we auto-format on push to `main` instead
